### PR TITLE
Tag mainnet-v1.36.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Multi-platform docker images for [Sui](https://sui.io/).
 
 These are built from the official release source code from [Sui](https://github.com/MystenLabs/sui/releases).
-The images are tagged with the corresponding release version, e.g. `mainnet-v1.35.4`.
+The images are tagged with the corresponding release version, e.g. `mainnet-v1.36.2`.
 
 Please refer to the [GitHub Packages](https://github.com/orgs/shinamicorp/packages?repo_name=sui-docker) page for available versions.
 
@@ -22,7 +22,7 @@ Please refer to the [GitHub Packages](https://github.com/orgs/shinamicorp/packag
   - Contains a single `sui-node` binary, geared towards running Sui fullnodes.
   - Image entrypoint set to `sui-node`, so you can directly run commands like this:
     ```
-    docker run --rm -it ghcr.io/shinamicorp/sui-node:mainnet-v1.32.2 --help
+    docker run --rm -it ghcr.io/shinamicorp/sui-node:mainnet-v1.36.2 --help
     ```
   - In practice, you'll need to mount volumes for config, genesis, and data storage etc.
 - [sui](https://github.com/shinamicorp/sui-docker/pkgs/container/sui)

--- a/sui
+++ b/sui
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 from subprocess import run
 
-SUI_IMAGE = "ghcr.io/shinamicorp/sui:mainnet-v1.35.4"
+SUI_IMAGE = "ghcr.io/shinamicorp/sui:mainnet-v1.36.2"
 
 
 def sui(*args: str) -> None:


### PR DESCRIPTION
It's the same commit as `testnet-v1.36.2`, so we can skip the build. Manually tagged the image already.